### PR TITLE
Rewrite autocomplete service in Go

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,48 @@
+# Autocomplete Test Assignment
+
+This repository contains a simple TCP autocomplete service implemented in Go.
+
+## Building
+
+Use the Go toolchain to build the server and the client:
+
+```bash
+go build -o server ./cmd/server
+go build -o client ./cmd/client
+```
+
+## Running the Server
+
+Generate a `word_freq.txt` file with words and frequencies (one per line,
+`<word> <freq>`). A helper script `mock.py` is provided to create a random file.
+
+```bash
+python mock.py          # produces word_freq.txt in the repo root
+./server --filename word_freq.txt --port 10000
+```
+
+## Running the Client
+
+In a separate terminal:
+
+```bash
+./client --host 127.0.0.1 --port 10000
+```
+
+Enter commands of the form `get <prefix>` to receive suggestions.
+
+## Testing
+
+The service has unit tests for command parsing, LRU cache and suggestion logic.
+Run all tests with:
+
+```bash
+go test ./...
+```
+
+`go vet` can also be run for static analysis:
+
+```bash
+go vet ./...
+```
+

--- a/cmd/client/main.go
+++ b/cmd/client/main.go
@@ -1,0 +1,38 @@
+package main
+
+import (
+	"bufio"
+	"flag"
+	"fmt"
+	"log"
+	"net"
+	"os"
+)
+
+func main() {
+	host := flag.String("host", "0.0.0.0", "server host")
+	port := flag.Int("port", 10000, "server port")
+	flag.Parse()
+
+	conn, err := net.Dial("tcp", fmt.Sprintf("%s:%d", *host, *port))
+	if err != nil {
+		log.Fatalf("failed to connect: %v", err)
+	}
+	defer conn.Close()
+
+	go func() {
+		scanner := bufio.NewScanner(conn)
+		for scanner.Scan() {
+			fmt.Println(scanner.Text())
+		}
+	}()
+
+	scanner := bufio.NewScanner(os.Stdin)
+	for scanner.Scan() {
+		text := scanner.Text() + "\n"
+		if _, err := conn.Write([]byte(text)); err != nil {
+			log.Printf("write error: %v", err)
+			return
+		}
+	}
+}

--- a/cmd/server/main.go
+++ b/cmd/server/main.go
@@ -1,0 +1,212 @@
+package main
+
+import (
+	"bufio"
+	"container/list"
+	"context"
+	"flag"
+	"fmt"
+	"log"
+	"net"
+	"os"
+	"sort"
+	"strings"
+	"sync"
+)
+
+// WordFreq holds a word and its frequency.
+type WordFreq struct {
+	Word      string
+	Frequency int
+}
+
+// parseWordFreq parses a line "<word> <frequency>".
+func parseWordFreq(line string) (WordFreq, error) {
+	parts := strings.Fields(line)
+	if len(parts) < 2 {
+		return WordFreq{}, fmt.Errorf("invalid word frequency line")
+	}
+	var wf WordFreq
+	wf.Word = parts[0]
+	_, err := fmt.Sscanf(parts[1], "%d", &wf.Frequency)
+	return wf, err
+}
+
+// loadWordFreq loads word frequencies from file.
+func loadWordFreq(path string) ([]WordFreq, error) {
+	f, err := os.Open(path)
+	if err != nil {
+		return nil, err
+	}
+	defer f.Close()
+
+	var res []WordFreq
+	scanner := bufio.NewScanner(f)
+	for scanner.Scan() {
+		wf, err := parseWordFreq(scanner.Text())
+		if err != nil {
+			continue
+		}
+		res = append(res, wf)
+	}
+	return res, scanner.Err()
+}
+
+// LRUCache is a simple LRU cache for prefix suggestions.
+type LRUCache struct {
+	cap   int
+	mu    sync.Mutex
+	list  *list.List
+	items map[string]*list.Element
+}
+
+type cacheEntry struct {
+	key   string
+	value []WordFreq
+}
+
+func newLRUCache(cap int) *LRUCache {
+	return &LRUCache{
+		cap:   cap,
+		list:  list.New(),
+		items: make(map[string]*list.Element),
+	}
+}
+
+func (c *LRUCache) Get(key string) ([]WordFreq, bool) {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	if elem, ok := c.items[key]; ok {
+		c.list.MoveToFront(elem)
+		return elem.Value.(*cacheEntry).value, true
+	}
+	return nil, false
+}
+
+func (c *LRUCache) Add(key string, value []WordFreq) {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	if elem, ok := c.items[key]; ok {
+		elem.Value.(*cacheEntry).value = value
+		c.list.MoveToFront(elem)
+		return
+	}
+	elem := c.list.PushFront(&cacheEntry{key: key, value: value})
+	c.items[key] = elem
+	if c.list.Len() > c.cap {
+		old := c.list.Back()
+		if old != nil {
+			c.list.Remove(old)
+			delete(c.items, old.Value.(*cacheEntry).key)
+		}
+	}
+}
+
+// Server is autocomplete tcp server.
+type Server struct {
+	wordFreq []WordFreq
+	cache    *LRUCache
+}
+
+func NewServer(wordFreq []WordFreq) *Server {
+	return &Server{wordFreq: wordFreq, cache: newLRUCache(128)}
+}
+
+func parseCommand(line string) (string, string, error) {
+	fields := strings.Fields(strings.TrimSpace(line))
+	if len(fields) != 2 || strings.ToLower(fields[0]) != "get" {
+		return "", "", fmt.Errorf("Command should match pattern 'get <prefix:str>'")
+	}
+	prefix := fields[1]
+	if len(prefix) < 1 || len(prefix) > 15 {
+		return "", "", fmt.Errorf("Command should match pattern 'get <prefix:str>'")
+	}
+	if !isAlpha(prefix) {
+		return "", "", fmt.Errorf("Command should match pattern 'get <prefix:str>'")
+	}
+	return fields[0], prefix, nil
+}
+
+func isAlpha(s string) bool {
+	for _, r := range s {
+		if r < 'A' || (r > 'Z' && r < 'a') || r > 'z' {
+			return false
+		}
+	}
+	return true
+}
+
+func (s *Server) getSuggestions(prefix string) []WordFreq {
+	if val, ok := s.cache.Get(prefix); ok {
+		return val
+	}
+	var res []WordFreq
+	for _, wf := range s.wordFreq {
+		if strings.HasPrefix(wf.Word, prefix) {
+			res = append(res, wf)
+		}
+	}
+	sort.Slice(res, func(i, j int) bool {
+		if res[i].Frequency == res[j].Frequency {
+			return res[i].Word < res[j].Word
+		}
+		return res[i].Frequency > res[j].Frequency
+	})
+	if len(res) > 10 {
+		res = res[:10]
+	}
+	s.cache.Add(prefix, res)
+	return res
+}
+
+func (s *Server) handleConn(ctx context.Context, conn net.Conn) {
+	defer conn.Close()
+	fmt.Fprintln(conn, "This is autocomplete service.")
+	fmt.Fprintln(conn, "Service accepts commands, which")
+	fmt.Fprintln(conn, "matches 'get <prefix>' pattern")
+	scanner := bufio.NewScanner(conn)
+	for scanner.Scan() {
+		line := scanner.Text()
+		_, prefix, err := parseCommand(line)
+		if err != nil {
+			fmt.Fprintln(conn, err.Error())
+			continue
+		}
+		suggestions := s.getSuggestions(prefix)
+		if len(suggestions) == 0 {
+			fmt.Fprintln(conn, "Suggestions not found")
+			continue
+		}
+		for _, item := range suggestions {
+			fmt.Fprintf(conn, "-> %s\n", item.Word)
+		}
+	}
+}
+
+func main() {
+	filename := flag.String("filename", "word_freq.txt", "path to word freq file")
+	port := flag.Int("port", 10000, "listen port")
+	flag.Parse()
+
+	words, err := loadWordFreq(*filename)
+	if err != nil {
+		log.Fatalf("failed to load word freq file: %v", err)
+	}
+
+	srv := NewServer(words)
+
+	ln, err := net.Listen("tcp", fmt.Sprintf(":%d", *port))
+	if err != nil {
+		log.Fatalf("failed to listen: %v", err)
+	}
+	log.Printf("Server running on %s", ln.Addr())
+
+	for {
+		conn, err := ln.Accept()
+		if err != nil {
+			log.Printf("accept error: %v", err)
+			continue
+		}
+		go srv.handleConn(context.Background(), conn)
+	}
+}

--- a/cmd/server/main_test.go
+++ b/cmd/server/main_test.go
@@ -1,0 +1,97 @@
+package main
+
+import (
+	"os"
+	"reflect"
+	"testing"
+)
+
+func TestParseWordFreq(t *testing.T) {
+	wf, err := parseWordFreq("hello 42")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if wf.Word != "hello" || wf.Frequency != 42 {
+		t.Fatalf("unexpected value: %#v", wf)
+	}
+	if _, err := parseWordFreq("invalid_line"); err == nil {
+		t.Fatalf("expected error")
+	}
+}
+
+func TestParseCommand(t *testing.T) {
+	cmd, prefix, err := parseCommand("get test")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if cmd != "get" || prefix != "test" {
+		t.Fatalf("unexpected: %s %s", cmd, prefix)
+	}
+
+	cases := []string{"", "get", "get 123", "set test", "get verylongprefixmorethan15"}
+	for _, c := range cases {
+		if _, _, err := parseCommand(c); err == nil {
+			t.Errorf("expected error for %q", c)
+		}
+	}
+}
+
+func TestIsAlpha(t *testing.T) {
+	if !isAlpha("abc") {
+		t.Fatal("expected true")
+	}
+	if isAlpha("ab3") {
+		t.Fatal("expected false")
+	}
+}
+
+func TestLRUCache(t *testing.T) {
+	cache := newLRUCache(2)
+	a := []WordFreq{{Word: "a", Frequency: 1}}
+	b := []WordFreq{{Word: "b", Frequency: 1}}
+	c := []WordFreq{{Word: "c", Frequency: 1}}
+
+	cache.Add("a", a)
+	cache.Add("b", b)
+	if _, ok := cache.Get("a"); !ok {
+		t.Fatal("expected to find a")
+	}
+	cache.Add("c", c)
+	if _, ok := cache.Get("b"); ok {
+		t.Fatal("expected b to be evicted")
+	}
+}
+
+func TestGetSuggestions(t *testing.T) {
+	words := []WordFreq{{"app", 10}, {"apple", 5}, {"apples", 7}, {"banana", 3}}
+	srv := NewServer(words)
+	res := srv.getSuggestions("app")
+	got := make([]string, len(res))
+	for i, wf := range res {
+		got[i] = wf.Word
+	}
+	expected := []string{"app", "apples", "apple"}
+	if !reflect.DeepEqual(got, expected) {
+		t.Fatalf("got %v want %v", got, expected)
+	}
+}
+
+func TestLoadWordFreq(t *testing.T) {
+	tmp, err := os.CreateTemp(t.TempDir(), "wf.txt")
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer tmp.Close()
+	if _, err := tmp.WriteString("hello 1\nworld 2\n"); err != nil {
+		t.Fatal(err)
+	}
+	tmp.Close()
+
+	res, err := loadWordFreq(tmp.Name())
+	if err != nil {
+		t.Fatalf("load error: %v", err)
+	}
+	if len(res) != 2 {
+		t.Fatalf("unexpected length %d", len(res))
+	}
+}

--- a/go.mod
+++ b/go.mod
@@ -1,0 +1,3 @@
+module example.com/autocomplete
+
+go 1.23.8


### PR DESCRIPTION
## Summary
- add Go module
- implement `cmd/server` with caching and concurrency
- implement simple `cmd/client` to interact with the server

## Testing
- `go vet ./...`
- `go build ./cmd/server ./cmd/client`


------
https://chatgpt.com/codex/tasks/task_e_68406df9635c832ab66b89ad6abda635